### PR TITLE
Use MAP_FILE only when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,8 @@ AC_CHECK_HEADERS([libgen.h fcntl.h limits.h inttypes.h malloc.h stdint.h stdlib.
 			   CommonCrypto/CommonDigest.h
 			   ])
 
-
+# Definition of MAP_FILE is missing e.g. on Solaris
+AC_CHECK_DECLS([MAP_FILE])
 
 # These functions not available everywhere
 AC_CHECK_FUNCS([_gmtime64_s _gmtime64 gmtime_r mmap usleep mkstemp vasprintf getrusage getprogname isxdigit])

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -274,7 +274,11 @@ void file_data_hasher_t::hash()
 		return;
 	    }
 #ifdef HAVE_MMAP
-	    fdht->base = (uint8_t *)mmap(0,fdht->stat_bytes,PROT_READ,MAP_FILE|MAP_SHARED,fd,0);
+	    fdht->base = (uint8_t *)mmap(0,fdht->stat_bytes,PROT_READ,
+#if HAVE_DECL_MAP_FILE
+		MAP_FILE|
+#endif
+		MAP_SHARED,fd,0);
 	    if(fdht->base>0){		
 		/* mmap is successful, so set the bounds.
 		 * if it is not successful, we default to reading the fd


### PR DESCRIPTION
Hi,

this uses MAP_FILE for mmap only if it is available. This is e.g. on Solaris 10 not the case and must not be used.

Best regards

  -- Dago
