### PR TITLE
Revise DFXML output to validate against pending schema

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -812,15 +812,13 @@ void display::dfxml_startup(int argc,char **argv)
 {
     if(dfxml){
 	lock();
-	dfxml->push("dfxml","xmloutputversion='1.0'");
-	dfxml->push("metadata",
-		       "\n  xmlns='http://md5deep.sourceforge.net/md5deep/' "
+	dfxml->push("dfxml",
+		       "\n  xmlns='http://www.forensicswiki.org/wiki/Category:Digital_Forensics_XML' "
+		       "\n  xmlns:deep='http://md5deep.sourceforge.net/md5deep/' "
 		       "\n  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
-		       "\n  xmlns:dc='http://purl.org/dc/elements/1.1/'" );
-	dfxml->xmlout("dc:type","Hash List","",false);
-	dfxml->pop();
-	dfxml->add_DFXML_creator(PACKAGE_NAME,PACKAGE_VERSION,XML::make_command_line(argc,argv));
-	dfxml->push("configuration");
+		       "\n  xmlns:dc='http://purl.org/dc/elements/1.1/' "
+		       "version='1.0'");
+	dfxml->push("deep:configuration");
 	dfxml->push("algorithms");
 	for(int i=0;i<NUM_ALGORITHMS;i++){
 	    dfxml->make_indent();
@@ -829,6 +827,10 @@ void display::dfxml_startup(int argc,char **argv)
 	}
 	dfxml->pop();			// algorithms
 	dfxml->pop();			// configuration
+	dfxml->push("metadata", "");
+	dfxml->xmlout("dc:type","Hash List","",false);
+	dfxml->pop();
+	dfxml->add_DFXML_creator(PACKAGE_NAME,PACKAGE_VERSION,XML::make_command_line(argc,argv));
 	unlock();
     }
 }
@@ -854,8 +856,8 @@ void display::dfxml_write(file_data_hasher_t *fdht)
 	dfxml->push("fileobject",attrs);
 	dfxml->xmlout("filename",fdht->file_name);
 	dfxml->xmlout("filesize",(int64_t)fdht->stat_bytes);
-	if(fdht->ctime) dfxml_timeout("ctime",fdht->ctime);
 	if(fdht->mtime) dfxml_timeout("mtime",fdht->mtime);
+	if(fdht->ctime) dfxml_timeout("ctime",fdht->ctime);
 	if(fdht->atime) dfxml_timeout("atime",fdht->atime);
 	dfxml->writexml(fdht->dfxml_hash.str());
 	dfxml->pop();


### PR DESCRIPTION
If this patch is accepted, Hashdeep's DFXML output will validate
against the DFXML schema as in this branch:
https://github.com/ajnelson/dfxml_schema/tree/archive/for_hashdeep_v0

The changes from that schema branch will be merged into the upstream
DFXML schema after a request-for-comments period (assuming no
objections).

This patch has not been tested beyond these commands:

```
git clone --branch=validate_dfxml https://github.com/ajnelson/hashdeep.git
git clone --branch=archive/for_hashdeep_v0 https://github.com/ajnelson/dfxml_schema.git
cd hashdeep
sh bootstrap.sh && ./configure --prefix=$PWD/build && make -j && make install
build/bin/hashdeep -d -r . >test_hashdeep.xml
xmllint --noout --schema ../dfxml_schema/dfxml.xsd test_hashdeep.xml
```

The output of the last command was:

```
test_hashdeep.xml validates
```
