### PR TITLE
Fix #303

### DIFF
--- a/src/dig.cpp
+++ b/src/dig.cpp
@@ -112,7 +112,6 @@ int file_metadata_t::stat(const tstring &fn,
 	FILE *f = _tfopen(fn.c_str(),_TEXT("rb"));
 	if(f){
 		m->size = find_file_size(f,&ocb);
-                std::cout << "m->size = " << m->size << "\n";
 		fclose(f); f = 0;
 	}
   }


### PR DESCRIPTION
This will fix https://github.com/jessek/hashdeep/issues/303 (and https://github.com/jessek/hashdeep/issues/165). I use the same method of obtaining raw device size as in file_types state::file_type().
