### PR TITLE
Fix errors found by clang

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -279,7 +279,7 @@ void file_data_hasher_t::hash()
 		MAP_FILE|
 #endif
 		MAP_SHARED,fd,0);
-	    if(fdht->base>0){		
+	    if(fdht->base != (void *) -1){
 		/* mmap is successful, so set the bounds.
 		 * if it is not successful, we default to reading the fd
 		 */


### PR DESCRIPTION
Fixes errors like

../../git/src/hash.cpp:282:19: error: ordered comparison between pointer and zero ('const unsigned char *' and 'int')
            if(fdht->base>0){
               ~~~~~~~~~~^~

Signed-off-by: Khem Raj <raj.khem@gmail.com>