### PR TITLE
Fix literal and identifier spacing as dictated by C++11

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -311,7 +311,7 @@ void display::display_realtime_stats(const file_data_hasher_t *fdht, const hash_
 
 	ss << mb_read << "MB of " << fdht->stat_megs() << "MB done, ";
 	char msg[64];
-	snprintf(msg,sizeof(msg),"%02"PRIu64":%02"PRIu64":%02"PRIu64" left", hour, min, seconds);
+	snprintf(msg,sizeof(msg),"%02" PRIu64 ":%02" PRIu64 ":%02" PRIu64 " left", hour, min, seconds);
 	ss << msg;
     }
     ss << "\r";
@@ -424,14 +424,14 @@ void display::display_audit_results()
   
     if (opt_verbose)    {
 	if(opt_verbose >= MORE_VERBOSE){
-	    status("   Input files examined: %"PRIu64, this->match.total);
-	    status("  Known files expecting: %"PRIu64, this->match.expect);
+	    status("   Input files examined: %" PRIu64, this->match.total);
+	    status("  Known files expecting: %" PRIu64, this->match.expect);
 	}
-	status("          Files matched: %"PRIu64, this->match.exact);
-	status("Files partially matched: %"PRIu64, this->match.partial);
-	status("            Files moved: %"PRIu64, this->match.moved);
-	status("        New files found: %"PRIu64, this->match.unknown);
-	status("  Known files not found: %"PRIu64, this->match.unused);
+	status("          Files matched: %" PRIu64, this->match.exact);
+	status("Files partially matched: %" PRIu64, this->match.partial);
+	status("            Files moved: %" PRIu64, this->match.moved);
+	status("        New files found: %" PRIu64, this->match.unknown);
+	status("  Known files not found: %" PRIu64, this->match.unused);
     }
 }
 

--- a/src/files.cpp
+++ b/src/files.cpp
@@ -509,7 +509,7 @@ int state::parse_encase_file(const char *fn, FILE *handle,uint32_t expected_hash
         
 	    // Users expect the line numbers to start at one, not zero.
 	    if ((!ocb.opt_silent) || (mode_warn_only)) {
-		ocb.error("%s: No hash found in line %"PRIu32, fn, count + 1);
+		ocb.error("%s: No hash found in line %" PRIu32, fn, count + 1);
 		ocb.error("%s: %s", fn, strerror(errno));
 		return status_t::STATUS_USER_ERROR;
 	    }
@@ -542,7 +542,7 @@ int state::parse_encase_file(const char *fn, FILE *handle,uint32_t expected_hash
     }
 
     if (expected_hashes != count){
-	ocb.error("%s: Expecting %"PRIu32" hashes, found %"PRIu32"\n", 
+	ocb.error("%s: Expecting %" PRIu32 " hashes, found %" PRIu32 "\n", 
 			fn, expected_hashes, count);
     }
     return status_t::status_ok;

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -124,7 +124,7 @@ bool file_data_hasher_t::compute_hash(uint64_t request_start,uint64_t request_le
     
 	// If an error occured, display a message and see if we need to quit.
 	if ((current_read_bytes<0) || (this->handle && ferror(this->handle))){
-	    ocb->error_filename(this->file_name,"error at offset %"PRIu64": %s",
+	    ocb->error_filename(this->file_name,"error at offset %" PRIu64 ": %s",
 				request_start, strerror(errno));
 	   
 	    if (file_fatal_error()){

--- a/src/hashlist.cpp
+++ b/src/hashlist.cpp
@@ -342,7 +342,7 @@ hashlist::load_hash_file(display *ocb,const std::string &fn)
     file_data_t *t = new (std::nothrow) file_data_t();
     if (NULL == t)
     {
-      ocb->fatal_error("%s: Out of memory in line %"PRIu64,
+      ocb->fatal_error("%s: Out of memory in line %" PRIu64,
 		       fn.c_str(), line_number);
     }
 
@@ -390,7 +390,7 @@ hashlist::load_hash_file(display *ocb,const std::string &fn)
       if ( !algorithm_t::valid_hash(hash_column[column_number],word))
       {
 	if (ocb)
-	  ocb->error("%s: Invalid %s hash in line %"PRIu64,
+	  ocb->error("%s: Invalid %s hash in line %" PRIu64,
 		     fn.c_str(),
 		     hashes[hash_column[column_number]].name.c_str(),
 		     line_number);

--- a/src/xml.h
+++ b/src/xml.h
@@ -100,7 +100,7 @@ public:
     void xmlout(const std::string &tag,const std::string &value){ xmlout(tag,value,"",true); }
     void xmlout(const std::string &tag,const int value){ xmlprintf(tag,"","%d",value); }
     void xmloutl(const std::string &tag,const long value){ xmlprintf(tag,"","%ld",value); }
-    void xmlout(const std::string &tag,const int64_t value){ xmlprintf(tag,"","%"PRId64,value); }
+    void xmlout(const std::string &tag,const int64_t value){ xmlprintf(tag,"","%" PRId64,value); }
     void xmlout(const std::string &tag,const double value){ xmlprintf(tag,"","%f",value); }
     void xmlout(const std::string &tag,const struct timeval &ts){
 	xmlprintf(tag,"","%d.%06d",(int)ts.tv_sec, (int)ts.tv_usec);


### PR DESCRIPTION
Fixes clang error like below

error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
|         status("  Known files not found: %"PRIu64, this->match.unused);

Signed-off-by: Khem Raj <raj.khem@gmail.com>