### PR TITLE
Update hash.cpp

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -279,7 +279,7 @@ void file_data_hasher_t::hash()
 		MAP_FILE|
 #endif
 		MAP_SHARED,fd,0);
-	    if(fdht->base != (void *) -1){
+	    if (fdht->base != nullptr) {
 		/* mmap is successful, so set the bounds.
 		 * if it is not successful, we default to reading the fd
 		 */


### PR DESCRIPTION
Just to solve this issue:

hash.cpp: In member function ‘void file_data_hasher_t::hash()’: hash.cpp:282:26: error: ordered comparison of pointer with integer zero (‘const unsigned char*’ and ‘int’)
  282 |             if(fdht->base>0){
      |                ~~~~~~~~~~^~